### PR TITLE
Fixed dashboard for 1p

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Web dashboard for Deye solar inverters using the Solarman V5 protocol. Displays real-time solar production, battery status, grid power, and home consumption.
+Web dashboard for Deye solar inverters using the Solarman V5 protocol. Displays real-time solar production, battery status, grid power, home consumption, weather, and power outage schedules. Includes a Telegram bot for notifications in literary Ukrainian style.
 
 ## Development Commands
 
@@ -17,18 +17,53 @@ pip install -r requirements.txt
 # Run dashboard (http://localhost:8080)
 python app.py
 
+# Run locally with Telegram disabled
+./deploy_local.sh
+
+# Deploy to remote server (interactive setup on first run)
+./deploy.sh
+
 # Test inverter connection
 python test_connection.py
 
-# Scan available registers
-python scan_registers.py
+# Quick inverter health check
+python check_inverter.py
+
+# Diagnostic register scans
+python scan_registers.py    # all registers
+python scan_battery.py      # battery registers
+python scan_phases.py       # phase registers
 ```
 
 ## Architecture
 
-- `app.py` - Flask web server, serves dashboard and `/api/data` endpoint
-- `inverter.py` - `DeyeInverter` class for Modbus communication
-- `templates/index.html` - Dashboard UI with auto-refresh every 5 seconds
+### Core Components
+
+- **`app.py`** — Flask web server. Contains the main application, API routes, and background poller classes (`InverterPoller`, `WeatherPoller`). Serves the single-page dashboard at `/` and JSON API at `/api/*`. Manages phase stats, outage history, and grid daily logs as JSON files.
+
+- **`inverter.py`** — `DeyeInverter` class for Modbus communication via `pysolarmanv5`. Reads holding registers with 50ms delays between reads to avoid overwhelming the logger. `BatterySampler` runs in a separate thread to smooth voltage/SOC readings using a rolling buffer with outlier rejection. `InverterConfig` dataclass describes inverter capabilities (phases, battery, PV strings).
+
+- **`telegram_bot.py`** — Telegram bot with commands (`/battery`, `/outage`, `/grid`, `/test`). Sends notifications for low battery and grid restore events. Messages are written in 1800s literary Ukrainian style. Uses `poems.py` for weather-themed poetry excerpts.
+
+- **`templates/index.html`** — Single-page dashboard UI with auto-refresh every 5 seconds. Contains energy flow diagrams, phase analytics, outage history, and fullscreen kiosk mode. All frontend logic is inline (no build step).
+
+### Outage Providers
+
+`outage_providers/` is a provider pattern for power outage schedules:
+- `base.py` — `OutageProvider` base class, `OutageSchedulePoller` (background thread), and `create_outage_provider()` factory
+- `lvivoblenergo.py` — Lvivoblenergo schedule provider
+- `yasno.py` — Yasno (DTEK) schedule provider
+
+### Threading Model
+
+The app runs several daemon threads:
+- `InverterPoller` — polls inverter every 60s, caches to JSON file
+- `BatterySampler` — reads battery voltage/SOC every 10s for smoothing
+- `WeatherPoller` — fetches Open-Meteo weather every 15 min
+- `OutageSchedulePoller` — fetches outage schedule every 60s
+- `TelegramBot` — runs Telegram polling loop
+
+All pollers use thread locks for safe cache access. The inverter connection (`DeyeInverter.lock`) is shared between `InverterPoller` and `BatterySampler`.
 
 ## Inverter Connection
 
@@ -36,18 +71,57 @@ python scan_registers.py
 - Port 8899 (Solarman V5 protocol)
 - **Use holding registers** (`read_holding_registers`), not input registers
 - Slave ID: 1
+- Connection is opened per-poll and closed after each read cycle (see `read_all_data` → `disconnect()` in finally block)
+- 50ms sleep between register reads to reduce logger connection pressure
 - Configuration via environment variables: `INVERTER_IP`, `LOGGER_SERIAL`
+- Inverter capabilities (phases, battery, PV strings) auto-detected at startup via `detect_config()`
 
-## Key Registers (Holding)
+## Key Registers (Holding) — 3-Phase Hybrid
 
 | Register | Description | Scale |
 |----------|-------------|-------|
 | 514, 515 | PV1/PV2 Power | W |
-| 586 | Battery Voltage | /100 V |
-| 587 | Battery Current (signed) | /100 A |
+| 586 | Battery Current (signed) | /100 A |
+| 587 | Battery Voltage | /100 V |
 | 588 | Battery SOC | % |
 | 598 | Grid Voltage | /10 V |
 | 607 | Grid Power (signed) | W |
-| 653 | Load Power | W |
-| 540, 541 | DC/Heatsink Temp | (val-1000)/10 °C |
+| 644-646 | Phase Voltages L1-L3 | /10 V |
+| 650-653 | Phase Loads L1-L3, Total Load | W |
+| 540, 541 | DC/Heatsink Temp | (val-1000)/10 C |
 | 502, 520, 521, 526 | Daily PV/Import/Export/Load | /10 kWh |
+
+## Key Registers (Holding) — 1-Phase Hybrid (Sunsynk)
+
+| Register | Description | Scale |
+|----------|-------------|-------|
+| 186, 187 | PV1/PV2 Power | W |
+| 191 | Battery Current (signed, negate) | /100 A |
+| 183 | Battery Voltage | /100 V |
+| 184 | Battery SOC | % |
+| 150 | Grid Voltage | /10 V |
+| 169 | Grid Power (signed) | W |
+| 176, 178 | Load L1, Total Load | W |
+| 90, 91 | DC/Heatsink Temp | (val-1000)/10 C |
+| 108, 76, 77, 84 | Daily PV/Import/Export/Load | /10 kWh |
+
+## API Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/data` | GET | Current inverter readings |
+| `/api/weather` | GET | Current weather and forecast |
+| `/api/outage_schedule` | GET | Upcoming outage windows |
+| `/api/phase-stats` | GET | Daily phase statistics |
+| `/api/phase-history` | GET | Phase power history |
+| `/api/outages` | GET/POST | Outage history (read/record) |
+| `/api/outages/clear` | POST | Clear outage history |
+| `/api/phase-stats/clear` | POST | Clear phase statistics |
+
+## Configuration
+
+All via environment variables (`.env` file). See `.env.example` for full template.
+
+Required: `INVERTER_IP`, `LOGGER_SERIAL`
+
+Optional: `WEATHER_LATITUDE/LONGITUDE`, `OUTAGE_PROVIDER` (lvivoblenergo/yasno/none), `TELEGRAM_ENABLED`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_ALLOWED_USERS`

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Deye Solar Dashboard
 
-A web dashboard for monitoring Deye solar inverters in real-time. Displays solar production, battery status, grid power, home consumption, weather conditions, and power outage schedules.
+A web dashboard for monitoring Deye solar inverters in real-time. Supports both single-phase (e.g. SUN-6K-SG03LP1) and 3-phase hybrid models. Displays solar production, battery status, grid power, home consumption, weather conditions, and power outage schedules.
 
 ![Dashboard Preview](docs/preview.png)
 
 ## Features
 
 - **Real-time monitoring** — solar production, battery SOC, grid power, and load consumption
-- **3-phase load analytics** — per-phase power distribution with daily statistics
+- **Load analytics** — per-phase power distribution with daily statistics (3-phase systems)
 - **Weather** — current conditions and forecast via Open-Meteo API
 - **Outage schedule** — upcoming power outage windows (Lvivoblenergo or Yasno providers)
 - **Grid outage detection** — voice alerts and browser notifications when power goes out

--- a/app.py
+++ b/app.py
@@ -1,4 +1,10 @@
 """Deye Dashboard - Simple web dashboard for Deye solar inverters."""
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
 from flask import Flask, render_template, jsonify, request
 from inverter import DeyeInverter, BatterySampler, InverterConfig
 from telegram_bot import TelegramBot
@@ -582,4 +588,4 @@ if __name__ == "__main__":
     # - Otherwise skip (we're the reloader parent, child will start it)
     if os.environ.get("WERKZEUG_RUN_MAIN") == "true":
         start_telegram_bot()
-    app.run(host="0.0.0.0", port=8080, debug=True)
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 8080)), debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pysolarmanv5
 flask
 requests
+python-dotenv


### PR DESCRIPTION
Summary

  - Add single-phase (1P) hybrid inverter support using the Sunsynk register map (registers 60-200 range), verified on a SUN-6K-SG03LP1
  - The 3-phase code path is completely untouched — `_read_all_data_unlocked()` dispatches to `_read_1p_data_unlocked()` or `_read_3p_data_unlocked()`
   based on `config.phases`
  - `BatterySampler` selects the correct battery voltage/SOC registers per phase config (183/184 for 1P, 587/588 for 3P)
  - Add `python-dotenv` for `.env` loading and make the server port configurable via `PORT` env var

  ## Key 1P register mapping

  | Field | Register | Scale |
  |-------|----------|-------|
  | PV1/PV2 Power | 186, 187 | W |
  | Battery Voltage | 183 | /100 V |
  | Battery Current | 191 | /100 A, signed, negate |
  | Battery SOC | 184 | % |
  | Grid Voltage | 150 | /10 V |
  | Grid Power | 169 | W, signed |
  | Load Power | 178 | W |
  | Temps | 90, 91 | (val-1000)/10 C |
  | Daily stats | 108, 76, 77, 84 | /10 kWh |